### PR TITLE
Make flag groups model configurable in django settings

### DIFF
--- a/waffle/defaults.py
+++ b/waffle/defaults.py
@@ -5,6 +5,8 @@ COOKIE = 'dwf_%s'
 TEST_COOKIE = 'dwft_%s'
 SECURE = True
 MAX_AGE = 2592000  # 1 month in seconds
+FLAG_GROUP_MODEL = 'auth.Group'
+USER_FLAGS_GROUPS_ATTRIBUTE = 'groups'
 
 CACHE_PREFIX = 'waffle:'
 CACHE_NAME = 'default'

--- a/waffle/migrations/0001_initial.py
+++ b/waffle/migrations/0001_initial.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from django.db import models, migrations
 import django.utils.timezone
 from django.conf import settings
+from waffle.utils import get_setting
 
 
 class Migration(migrations.Migration):
@@ -30,7 +31,7 @@ class Migration(migrations.Migration):
                 ('note', models.TextField(help_text='Note where this Flag is used.', blank=True)),
                 ('created', models.DateTimeField(default=django.utils.timezone.now, help_text='Date when this Flag was created.', db_index=True)),
                 ('modified', models.DateTimeField(default=django.utils.timezone.now, help_text='Date when this Flag was last modified.')),
-                ('groups', models.ManyToManyField(help_text='Activate this flag for these user groups.', to='auth.Group', blank=True)),
+                ('groups', models.ManyToManyField(help_text='Activate this flag for these user groups.', to=get_setting('FLAG_GROUP_MODEL'), blank=True)),
                 ('users', models.ManyToManyField(help_text='Activate this flag for these users.', to=settings.AUTH_USER_MODEL, blank=True)),
             ],
             options={

--- a/waffle/migrations/0003_update_strings_for_i18n.py
+++ b/waffle/migrations/0003_update_strings_for_i18n.py
@@ -3,6 +3,8 @@
 from django.conf import settings
 from django.db import migrations, models
 import django.utils.timezone
+from waffle.utils import get_setting
+
 
 
 class Migration(migrations.Migration):
@@ -42,7 +44,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='flag',
             name='groups',
-            field=models.ManyToManyField(blank=True, help_text='Activate this flag for these user groups.', to='auth.Group', verbose_name='Groups'),
+            field=models.ManyToManyField(blank=True, help_text='Activate this flag for these user groups.', to=get_setting('FLAG_GROUP_MODEL'), verbose_name='Groups'),
         ),
         migrations.AlterField(
             model_name='flag',

--- a/waffle/models.py
+++ b/waffle/models.py
@@ -167,7 +167,7 @@ class Flag(BaseModel):
         verbose_name=_('Languages'),
     )
     groups = models.ManyToManyField(
-        Group,
+        get_setting('FLAG_GROUP_MODEL'),
         blank=True,
         help_text=_('Activate this flag for these user groups.'),
         verbose_name=_('Groups'),
@@ -264,10 +264,12 @@ class Flag(BaseModel):
         if hasattr(user, 'pk') and user.pk in user_ids:
             return True
 
-        if hasattr(user, 'groups'):
+        flags_groups_attr_name = get_setting('USER_FLAGS_GROUPS_ATTRIBUTE')
+        if hasattr(user, flags_groups_attr_name):
             group_ids = self._get_group_ids()
-            user_groups = set(user.groups.all().values_list('pk', flat=True))
-            if group_ids.intersection(user_groups):
+            user_groups = getattr(user, flags_groups_attr_name).all()
+            user_groups_ids = set(user_groups.values_list('pk', flat=True))
+            if group_ids.intersection(user_groups_ids):
                 return True
         return None
 


### PR DESCRIPTION
This is useful if you don't want to mix user roles with flags groups. In this commit I added two new settings:  `FLAG_GROUP_MODEL` and `USER_FLAGS_GROUPS_ATTRIBUTE`.

* **FLAG_GROUP_MODEL** defines which is the model that should be used in Flag's groups attribute. The default value is `'auth.Group'`;
* **USER_FLAGS_GROUPS_ATTRIBUTE** defines which attribute from user model should we use to retrieve its groups. The default value is `'groups'`.

This commit also modified the Flags model and its migrations to use `FLAG_GROUP_MODEL` instead of `auth.Group`. Also modifies the `is_active_for_user` method to retrieve user groups using `USER_FLAGS_GROUPS_ATTRIBUTE`.

None of the changes introduced is breaking.